### PR TITLE
fix(platform): add PUT HTTP method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ If you like this project and find it useful, please consider giving it a star on
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/bmc-button.svg" alt="Buy me a coffee" width="120"></a>
 
+## [Unreleased]
+
+### Added
+
+- [platform]: Added PUT HTTP method support for webhooks and webhook devices.
+
 ## [1.1.0] - 2025-12-16
 
 ### Added Webhook devices

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 
 - The webhooks parameters can easily be entered in the frontend.
 - It is possible to choose how to expose the webhooks: Switch, Outlet or Light.
-- It is possible to choose the method: GET or POST.
+- It is possible to choose the method: GET, POST or PUT.
 - The webhook can be tested in the frontend.
 
 # Webhook devices
@@ -31,7 +31,7 @@ Features:
 Features:
 
 - It is possible to choose the device type from the config.
-- It is possible to set the method with a prefix 'GET#' or 'POST# in the urls. Default if omitted is GET.
+- It is possible to set the method with a prefix 'GET#', 'POST#' or 'PUT#' in the urls. Default if omitted is GET.
 - It is possible to use converters and attributes in the url.
 
 ## Supported device types:
@@ -87,7 +87,7 @@ See the complete guidelines on [Matterbridge](https://matterbridge.io/README.htm
 
 ## How to add a simple webhook
 
-In the frontend open the plugin config: add a new webhook, enter the webhook name in the first field (replace newKey with the name you want to give to the webhook), select GET or POST and enter the webhook url. The webhook name will be the device name on the controller. The webhook will be exposed like a switch, like an outlet or like a light. When you turn it on, the webhook is called and in a few seconds the switch or the outlet or the light will revert to off.
+In the frontend open the plugin config: add a new webhook, enter the webhook name in the first field (replace newKey with the name you want to give to the webhook), select GET, POST or PUT and enter the webhook url. The webhook name will be the device name on the controller. The webhook will be exposed like a switch, like an outlet or like a light. When you turn it on, the webhook is called and in a few seconds the switch or the outlet or the light will revert to off.
 
 It is possible to test directly the webhook from the config editor.
 

--- a/matterbridge-webhooks.schema.json
+++ b/matterbridge-webhooks.schema.json
@@ -58,7 +58,7 @@
           "method": {
             "type": "string",
             "default": "GET",
-            "enum": ["GET", "POST"],
+            "enum": ["GET", "POST", "PUT"],
             "description": "HTTP method to use for the webhook."
           },
           "httpUrl": {
@@ -76,7 +76,7 @@
       }
     },
     "outlets": {
-      "description": "Define each outlet. Enter in the first field the name of the outlet (replace newKey with the name of the outlet) and in the right panel the urls (i.e. \"[GET|POST]#http://mydomain.com/api/device/on\").",
+      "description": "Define each outlet. Enter in the first field the name of the outlet (replace newKey with the name of the outlet) and in the right panel the urls (i.e. \"[GET|POST|PUT]#http://mydomain.com/api/device/on\").",
       "type": "object",
       "uniqueItems": true,
       "additionalProperties": {
@@ -98,7 +98,7 @@
       }
     },
     "lights": {
-      "description": "Define each light. Enter in the first field the name of the light (replace newKey with the name of the light) and in the right panel the urls (i.e. [GET|POST]#http://mydomain.com/api/device/on).",
+      "description": "Define each light. Enter in the first field the name of the light (replace newKey with the name of the light) and in the right panel the urls (i.e. [GET|POST|PUT]#http://mydomain.com/api/device/on).",
       "type": "object",
       "uniqueItems": true,
       "additionalProperties": {
@@ -131,17 +131,17 @@
           "brightnessUrl": {
             "type": "string",
             "title": "Light Brightness URL",
-            "description": "URL to adjust the brightness of the light. (i.e. [GET|POST]:http://mydomain.com/api/device?brightness=${BRIGHTNESS})"
+            "description": "URL to adjust the brightness of the light. (i.e. [GET|POST|PUT]#http://mydomain.com/api/device?brightness=${BRIGHTNESS})"
           },
           "colorTempUrl": {
             "type": "string",
             "title": "Light Color Temperature URL",
-            "description": "URL to adjust the color temperature of the light. (i.e. [GET|POST]:http://mydomain.com/api/device?colorTemp=${MIRED})"
+            "description": "URL to adjust the color temperature of the light. (i.e. [GET|POST|PUT]#http://mydomain.com/api/device?colorTemp=${MIRED})"
           },
           "rgbUrl": {
             "type": "string",
             "title": "Light RGB URL",
-            "description": "URL to adjust the RGB color of the light. (i.e. [GET|POST]:http://mydomain.com/api/device?hue=${HUE}&saturation=${SATURATION})"
+            "description": "URL to adjust the RGB color of the light. (i.e. [GET|POST|PUT]#http://mydomain.com/api/device?hue=${HUE}&saturation=${SATURATION})"
           }
         }
       }

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -100,6 +100,27 @@ describe('fetch test', () => {
     expect(result).toEqual(postData);
   });
 
+  test('Successful PUT request', async () => {
+    // Server echoes back the PUT JSON.
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(body);
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+
+    const putData = { key: 'updated', num: 100 };
+    const result = await fetch<typeof putData>(baseUrl, 'PUT', putData);
+    expect(result).toEqual(putData);
+  });
+
   test('Non-success status code should reject', async () => {
     // Server responds with 404.
     server = http.createServer((req, res) => {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -36,12 +36,12 @@ interface JsonArray extends Array<JsonValue> {}
  * Fetches data from a given URL using the specified method and data.
  *
  * @param {string} url - The URL to fetch data from.
- * @param {'POST' | 'GET'} method - The HTTP method to use for the request. Defaults to 'GET'.
+ * @param {'POST' | 'GET' | 'PUT'} method - The HTTP method to use for the request. Defaults to 'GET'.
  * @param {Record<string, JsonValue>} data - The data to send with the request, if applicable. Defaults to an empty object.
  * @param {number} timeout - The timeout for the request in milliseconds. Defaults to 5000ms (5 seconds).
  * @returns {Promise<T>} - A promise that resolves to the parsed JSON response.
  */
-export async function fetch<T>(url: string, method: 'POST' | 'GET' = 'GET', data: Record<string, JsonValue> = {}, timeout = 5000): Promise<T> {
+export async function fetch<T>(url: string, method: 'POST' | 'GET' | 'PUT' = 'GET', data: Record<string, JsonValue> = {}, timeout = 5000): Promise<T> {
   return new Promise((resolve, reject) => {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
@@ -78,7 +78,7 @@ export async function fetch<T>(url: string, method: 'POST' | 'GET' = 'GET', data
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        ...(method === 'POST' && { 'Content-Length': Buffer.byteLength(jsonData) }),
+        ...((method === 'POST' || method === 'PUT') && { 'Content-Length': Buffer.byteLength(jsonData) }),
       },
       signal: controller.signal,
     };
@@ -116,8 +116,8 @@ export async function fetch<T>(url: string, method: 'POST' | 'GET' = 'GET', data
       reject(new Error(`Request failed: ${error instanceof Error ? error.message : error}`));
     });
 
-    // Send the JSON data only if the method is POST
-    if (method === 'POST') {
+    // Send the JSON data only if the method is POST or PUT
+    if (method === 'POST' || method === 'PUT') {
       req.write(jsonData);
     }
     req.end();

--- a/src/module.ts
+++ b/src/module.ts
@@ -44,7 +44,7 @@ import { ColorControl, LevelControl } from 'matterbridge/matter/clusters';
 import { fetch } from './fetch.js';
 
 export interface WebhookConfig {
-  method: 'POST' | 'GET';
+  method: 'POST' | 'GET' | 'PUT';
   httpUrl: string;
   test: boolean;
 }
@@ -311,15 +311,15 @@ export class WebhooksPlatform extends MatterbridgeDynamicPlatform {
    * @param {string} command - The command to parse.
    * @param {string} url - The URL to parse.
    * @param {CommandHandlerData} [data] - The command handler data.
-   * @returns {Promise<{ method: 'POST' | 'GET'; url: string }>} - The parsed method and URL.
+   * @returns {Promise<{ method: 'POST' | 'GET' | 'PUT'; url: string }>} - The parsed method and URL.
    */
-  async parseUrl(deviceType: string, deviceName: string, command: string, url: string, data: CommandHandlerData): Promise<{ method: 'POST' | 'GET'; url: string }> {
+  async parseUrl(deviceType: string, deviceName: string, command: string, url: string, data: CommandHandlerData): Promise<{ method: 'POST' | 'GET' | 'PUT'; url: string }> {
     this.log.info(`Webhook ${deviceType} ${deviceName} ${command} triggered`);
     const endpoint = data.endpoint;
     this.log.debug(`Webhook ${deviceType} ${deviceName} ${command} triggered on endpoint ${endpoint?.deviceName}`);
 
     // Determine method
-    let method: 'POST' | 'GET' = 'GET';
+    let method: 'POST' | 'GET' | 'PUT' = 'GET';
     let parsedUrl = url;
     if (url.startsWith('GET#')) {
       method = 'GET';
@@ -327,6 +327,9 @@ export class WebhooksPlatform extends MatterbridgeDynamicPlatform {
     } else if (url.startsWith('POST#')) {
       method = 'POST';
       parsedUrl = url.replace('POST#', '');
+    } else if (url.startsWith('PUT#')) {
+      method = 'PUT';
+      parsedUrl = url.replace('PUT#', '');
     }
 
     // Request based replacements


### PR DESCRIPTION
## Summary

Adds PUT HTTP method support for webhooks and webhook devices.

## Motivation

Some IoT device APIs require PUT requests for updating state. A notable example is the **Elgato Key Light API**, which uses `PUT /elgato/lights` to control light settings (brightness, color temperature, on/off state).

## References

- [Elgato Key Light API Documentation](https://github.com/adamesch/elgato-key-light-api) - Documents that Key Light devices use PUT requests for the `/elgato/lights` endpoint
- [Hacking Elgato Key Light with Postman](https://apihandyman.io/hacking-elgato-key-light-with-postman/) - Demonstrates PUT is required for controlling lights
- [python-elgato library (Home Assistant)](https://github.com/frenck/python-elgato/blob/main/src/elgato/elgato.py#L141) - Home Assistant's Elgato integration uses PUT for `state()` method

## Changes

- Extended `fetch()` method parameter type to include `'PUT'` alongside `'GET'` and `'POST'`
- PUT requests send data in request body (same behavior as POST per HTTP spec)
- Added `'PUT#'` URL prefix parsing for webhook devices
- Updated `WebhookConfig` interface to support PUT method
- Updated configuration schema with PUT option and documentation examples
- Updated README documentation
- Added CHANGELOG entry
- Added test case for PUT requests